### PR TITLE
return json struct to prevent 502 error on the API gateway

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,8 +31,8 @@ app.use(bodyParser.json());
 app.post('/calwebhook', (req, res) => {
     console.log(`received a webhook event (cal.com): ${JSON.stringify(req.body)}`)
     Promise
-        .resolve()
-        .then(() => calEventHandler(req.body))
+        .resolve(calEventHandler(req.body))
+        .then(() => res.json({ status: 200, message: 'success' }))
         .catch((err) => {
             console.error(err);
             res.status(500).end();


### PR DESCRIPTION
For API Gateway to handle a Lambda function's response, the function must return output according to the following JSON format.

doc: https://repost.aws/knowledge-center/malformed-502-api-gateway